### PR TITLE
Add directives that 'declare' the custom tags used in the Modal Component

### DIFF
--- a/ng-semantic.ts
+++ b/ng-semantic.ts
@@ -2,7 +2,7 @@ import { SemanticMenuComponent } from "./ng-semantic/menu/menu";
 import { SemanticMessageComponent } from "./ng-semantic/message/message";
 import { SMTooltipDirective } from "./ng-semantic/popup/tooltip";
 import { SemanticPopupComponent } from "./ng-semantic/popup/popup";
-import { SemanticModalComponent } from "./ng-semantic/modal/modal";
+import { SemanticModalComponent, SMModalTagsDirective } from "./ng-semantic/modal/modal";
 import { SemanticSegmentComponent } from "./ng-semantic/segment/segment";
 import { SemanticListComponent } from "./ng-semantic/list/list";
 import { SemanticButtonComponent } from "./ng-semantic/button/button";
@@ -87,7 +87,9 @@ export let SEMANTIC_COMPONENTS: Array<any> = [
 export let SEMANTIC_DIRECTIVES: Array<any> = [
 	SMTooltipDirective,
 	SMVisibilityDirective,
-	SMDeviceVisibilityDirective
+	SMDeviceVisibilityDirective,
+	// directives with no functionality, simply declare tags
+	SMModalTagsDirective,
 ];
 
 import { NgModule } from "@angular/core";

--- a/ng-semantic/modal/modal.d.ts
+++ b/ng-semantic/modal/modal.d.ts
@@ -7,3 +7,5 @@ export declare class SemanticModalComponent {
     show(data?: {}): void;
     hide(): void;
 }
+export declare class SMModalTagsDirective {
+}

--- a/ng-semantic/modal/modal.ts
+++ b/ng-semantic/modal/modal.ts
@@ -1,4 +1,4 @@
-import { Component, Input, ChangeDetectionStrategy, ViewChild, ElementRef } from "@angular/core";
+import { Component, Input, ChangeDetectionStrategy, ViewChild, ElementRef, Directive } from "@angular/core";
 
 declare var jQuery: any;
 
@@ -40,4 +40,10 @@ export class SemanticModalComponent {
         jQuery(this.modal.nativeElement)
             .modal("hide");
     }
+}
+
+@Directive({selector: 'modal-content, modal-actions'})
+export class SMModalTagsDirective {
+  // No behavior
+  // The only purpose is to "declare" the tag in Angular2
 }


### PR DESCRIPTION
Create a directive that declares the custom tags used in the modal directive. This indicates to Angular2 that they are valid tags. Fixes https://github.com/vladotesanovic/ngSemantic/issues/127

See https://github.com/angular/angular/issues/11251#issuecomment-244255512 for discussion.