### PR TITLE
Fixed Null(undefined) dropdown item on dropdown reset defaults action

### DIFF
--- a/ng-semantic/dropdown/dropdown.ts
+++ b/ng-semantic/dropdown/dropdown.ts
@@ -29,7 +29,7 @@ export class SemanticDropdownComponent implements AfterViewInit {
 
         const options: {} = Object.assign({
             onChange: (value: string|number, a: string|number, b: Array<HTMLElement>) => {
-                if (b.length) {
+                if (b != null && b.length) {
                     this.onChange.emit(b[0].innerText);
                 }
             }


### PR DESCRIPTION
This fixes the problem with item with uidentified length when dropdown "restore defaults" action.