### PR TITLE
Fix sm-select two-way binding.

### DIFF
--- a/src/select/select.js
+++ b/src/select/select.js
@@ -39,7 +39,7 @@ var SemanticSelectComponent = (function () {
             var _this = this;
             if (data) {
                 setTimeout(function () {
-                    jQuery(_this.select.nativeElement).dropdown("set selected", data);
+                    jQuery(_this.select.nativeElement).dropdown("set exactly", data);
                 }, 1);
             }
         },

--- a/src/select/select.ts
+++ b/src/select/select.ts
@@ -42,7 +42,7 @@ export class SemanticSelectComponent implements AfterViewInit {
   set model(data: string|number) {
     if (data) {
       setTimeout(() => {
-        jQuery(this.select.nativeElement).dropdown("set selected", data);
+        jQuery(this.select.nativeElement).dropdown("set exactly", data);
       }, 1);
     }
   }


### PR DESCRIPTION
When using dropdown('set selected') with a multi select dropdown it selects the given options but does not deselect already selected options. Using the "set exactly" command replaces the selection.