### PR TITLE
Fixed sidebar overflow - #150

### DIFF
--- a/demo/assets/css/style.css
+++ b/demo/assets/css/style.css
@@ -43,6 +43,7 @@ textarea.code { resize: none !important; }
     margin: 0;
     width: inherit;
     overflow: hidden;
+    min-height: 100%;
     will-change: transform;
 }
 


### PR DESCRIPTION
The sidebar was being cut at the screen height. Have added `min-height: 100%;` to fix. 