### PR TITLE
Adds instructions to fix problems with components that have transclus…

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,14 @@ Then you can use in a component as follows:
 
 ```javascript
 // Module
-import { NgModule } from "@angular/core";
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from "@angular/core";
 import { NgSemanticModule } from "ng-semantic";
 
 @NgModule({
     bootstrap:    [ AppComponent ],
     declarations: [ AppComponent ],
-    imports:      [ BrowserModule, NgSemanticModule ]
+    imports:      [ BrowserModule, NgSemanticModule ],
+    schemas: [ CUSTOM_ELEMENTS_SCHEMA ]
 })
 export class AppModule {}
 


### PR DESCRIPTION
Adds instructions to fix problems with components that have transclusion and a custom tag is present (e.g.: \<accordion-title\> within \<sm-accordion-item\> within \<sm-accordion\> )

Without this, your components won't work with angular 2.0.0+ final release (sept 14, 2016)

Fix found here: http://stackoverflow.com/questions/39428132/custom-elements-schema-added-to-ngmodule-schemas-still-showing-error