### PR TITLE
Change Input variables to public

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "vsicons.presets.angular": true
+}

--- a/src/input/input.ts
+++ b/src/input/input.ts
@@ -33,7 +33,7 @@ export class SemanticInputComponent implements OnInit {
   @Input() control: FormControl = new FormControl();
   @Output() modelChange: EventEmitter<string|number> = new EventEmitter<string|number>();
 
-  private isInsideForm: boolean = false;
+  public isInsideForm: boolean = false;
 
   constructor(public viewRef: ViewContainerRef) {
   }
@@ -68,7 +68,7 @@ export class SemanticInputComponent implements OnInit {
   selector: "sm-checkbox",
   template: `<div class="field" [ngClass]="{error: (!control.value && control?.validator) }">
     <div class="ui {{classType}} checkbox">
-      <input type="checkbox" 
+      <input type="checkbox"
       [attr.value]="value"
       [attr.type]="inputType" tabindex="0" [attr.name]="name" [formControl]="control" [attr.disabled]="disabled">
       <label *ngIf="label">{{label}}</label>
@@ -92,8 +92,8 @@ export class SemanticCheckboxComponent {
     }
   }
 
-  private inputType: string = "checkbox";
-  private classType = "checkbox";
+  public inputType: string = "checkbox";
+  public classType = "checkbox";
 }
 
 /**


### PR DESCRIPTION
Input.ts private variables accessed by template would fail in production building of angular cli version 1.0.2.
'ng build -prod'
See [stackoverflow](http://stackoverflow.com/questions/34574167/angular2-should-private-variables-be-accessible-in-the-template)